### PR TITLE
Remove Mockery dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "kriswallsmith/buzz": ">=v0.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": "dev-master@dev"
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": { "Cxsearch": "src" }

--- a/tests/Cxsearch/SearchTest.php
+++ b/tests/Cxsearch/SearchTest.php
@@ -4,7 +4,6 @@ namespace Cxsearch;
 
 use Buzz\Browser;
 use Cxsearch\FacetGroup\FacetGroup;
-use Mockery\Mock;
 
 /**
  * @group Search
@@ -232,8 +231,10 @@ class SearchTest extends \PHPUnit_Framework_TestCase
         $expectedFacetQuery = '?p_aq=query("Ford")&p_f=' . $facetQuery;
         $search = new Search($this->index);
 
-        $facetGroupMock = \Mockery::mock('Cxsearch\FacetGroup\FacetGroup');
-        $facetGroupMock->shouldReceive("buildQuery")->andReturn($facetQuery);
+        $facetGroupMock = $this->getMock('Cxsearch\FacetGroup\FacetGroup');
+        $facetGroupMock->expects($this->any())
+                       ->method("buildQuery")
+                       ->will($this->returnValue($facetQuery));
 
         $search->query('Ford')
             ->addFacetGroup($facetGroupMock);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-// $loader = require_once __DIR__ . "/../vendor/autoload.php";
-// var_dump($loader);
-// $loader->add('Cxsearch\\', __DIR__);


### PR DESCRIPTION
@jehoshua02 

> It would be good to submit a pull request from our fork to upstream while we are at it, but we wanted to refactor so the tests don't use Mockery and use phpunit mocks, like the original author is doing (when in Rome ...).

I changed the code where we were using Mockery and removed Mockery dependency. What do you think about merging this branch into our develop and trying to make pull request to original author?
