### PR TITLE
fix order of arguments in some tests

### DIFF
--- a/tests/Cxsearch/SearchTest.php
+++ b/tests/Cxsearch/SearchTest.php
@@ -100,7 +100,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase
             ->duplicateRemoval('line')
             ->dump($result);
         $result = urldecode($result);
-        $this->assertEquals($result, $expectedString);
+        $this->assertEquals($expectedString,$result);
     }
 
     /**
@@ -244,8 +244,8 @@ class SearchTest extends \PHPUnit_Framework_TestCase
         $result = urldecode($result);
 
         $this->assertEquals(
-            $result,
             $expectedFacetQuery,
+            $result,
             "Result and expecting strings does not match"
         );
     }
@@ -300,8 +300,8 @@ class SearchTest extends \PHPUnit_Framework_TestCase
         $actualResult = urldecode($actualResult);
 
         $this->assertEquals(
-            $actualResult,
-            $expectedResult
+            $expectedResult,
+            $actualResult
         );
     }
 


### PR DESCRIPTION
I noticed, that sometimes we are changing orders of arguments in assert*() functions.
First argument should be expected value.
If we do not follow this rule, it will create confusion when looking in phpunit output even if tests will be  passing. For example
--- Expected
+++ Actual
@@ @@
-'?p_aq=query("test") AND filter(rating:1) NOT filter(id:[1,3])'
+'?p_aq=query("test") AND filter(rating:1) NOT filter(id:[1,2])'

PHPUnit tells us that first line is expected value, but if arguments were flip-flopped, the first line will be actual value.
