### PR TITLE
Return Results instead of Pass By Reference

### DIFF
--- a/src/Cxsearch/Search.php
+++ b/src/Cxsearch/Search.php
@@ -259,8 +259,15 @@ class Search
         $result = $query;
     }
 
-    public function run(&$result)
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function run(&$result = null)
     {
+        if (count(func_get_args()) > 0) {
+          trigger_error('Use return value instead of &$result passed by reference.', E_USER_DEPRECATED);
+        }
+
         $query = $this->_buildQuery();
 
         $browser = $this->_index->getBrowser();
@@ -274,6 +281,8 @@ class Search
         }
         $data = json_decode($response->getContent());
         $result = new Result($this->_index, $data);
+
+        return $result;
     }
 }
 

--- a/tests/Cxsearch/SearchTest.php
+++ b/tests/Cxsearch/SearchTest.php
@@ -112,12 +112,12 @@ class SearchTest extends \PHPUnit_Framework_TestCase
     public function testRunSearch()
     {
         $search = new Search($this->index);
-        $search->query('Ford')
+        $result = $search->query('Ford')
             ->andQueryByLine('Classic Cars')
             ->andFilterByMsrpGT(20)
             ->prefixSuffix('description', '<b>', '</b>')
             ->sort(array('msrp' => 'asc'))
-            ->run($result);
+            ->run();
 
         $this->assertInstanceOf('Cxsearch\Search\Result', $result);
 
@@ -168,14 +168,14 @@ class SearchTest extends \PHPUnit_Framework_TestCase
     {
         $index = $this->getCxIndex(FALSE);
         $search = new Search($index);
-        $rs = $search->query('Ford')
+        $result = $search->query('Ford')
             ->andQueryByLine('Classic Cars')
             ->andFilterByMsrpGT(20)
             ->prefixSuffix('description', '<b>', '</b>')
             ->sort(array('msrp' => 'asc'))
-            ->run($result);
+            ->run();
 
-        $this->assertFalse($rs);
+        $this->assertFalse($result);
     }
 
    /**
@@ -222,7 +222,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase
     {
         $index = $this->getCxIndex(TRUE, '_all');
 
-        $index->newSearch()->query('ford')->run($foo);
+        $result = $index->newSearch()->query('ford')->run();
     }
 
     public function testAddFacetGroup()
@@ -356,5 +356,23 @@ class SearchTest extends \PHPUnit_Framework_TestCase
 
         // assert
         $this->assertEquals($expected, $actual, 'Search should support filter ranges');
+    }
+
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     */
+    public function testResultPassByReferenceBackwardCompatibility() {
+      $search = new Search($this->index);
+      $search->query('Ford')
+          ->andQueryByLine('Classic Cars')
+          ->andFilterByMsrpGT(20)
+          ->prefixSuffix('description', '<b>', '</b>')
+          ->sort(array('msrp' => 'asc'))
+          ->run($result);
+
+      $this->assertInstanceOf('Cxsearch\Search\Result', $result);
+
+      return $result;
     }
 }


### PR DESCRIPTION
We were going through torture trying to get Mockery to mock the pass by
reference argument so we can return a known result.

We eventually concluded that pass by reference is assinine in this case and
we wanted a return value instead.
